### PR TITLE
Fix Azure deployment: remove iapm/ redirects colliding with IAPM/ dir…

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,10 +119,8 @@ plugins:
         'Products/IAPM-Desktop/Guides/Installation/Mac/index.md': 'IAPM/3D/Guides/Installation/macOS/index.md'
         'Products/IAPM-Desktop/Guides/Uninstallation/Mac/index.md': 'IAPM/3D/Guides/Uninstallation/macOS/index.md'
 
-        # Old IAPM paths → IAPM/3D
-        'iapm/index.md': 'IAPM/3D/index.md'
-        'iapm/features/index.md': 'IAPM/3D/Features/index.md'
-        'iapm/guides/index.md': 'IAPM/3D/Guides/index.md'
+        # Old IAPM paths removed - 'iapm/' collides with real 'IAPM/' on case-insensitive filesystems
+        # 'iapm/index.md', 'iapm/features/index.md', 'iapm/guides/index.md' dropped
         'iapm-web/index.md': 'IAPM/Web/index.md'
 
         # Products/IAPM → IAPM/3D redirects (old intermediate structure)


### PR DESCRIPTION
…ectory

The redirects plugin generates HTML files at source paths. On Linux CI, 'iapm/index.html' (redirect) and 'IAPM/index.html' (real page) are separate directories. When Azure App Service extracts the zip on Windows, these collide case-insensitively, causing "FAILED TO INITIALIZE RUN FROM PACKAGE". This broke deployments since 1.17.0.

Removed: iapm/index.md, iapm/features/index.md, iapm/guides/index.md
Kept: iapm-web/index.md (no collision with IAPM/Web/)