### PR TITLE
Add instrumented/inferred service definitions to terms pages (SP-047)

### DIFF
--- a/docs/Resources/Terms-and-Concepts/APM/index.md
+++ b/docs/Resources/Terms-and-Concepts/APM/index.md
@@ -35,7 +35,7 @@ graph TD
 | **Instrumentation** | Proprietary agents | Standard OpenTelemetry (no lock-in) |
 | **Query complexity** | Complex DSL required | Ask Tessa in natural language |
 | **Collaboration** | Siloed dashboard views | Shared immersive space |
-| **Pricing** | Per-host + per-GB + per-feature | Simple per-node pricing |
+| **Pricing** | Per-host + per-GB + per-feature | Simple per-node pricing (node = instrumented service) |
 
 Traditional APM tools (Datadog, Dynatrace, New Relic) give you dashboards. IAPM lets you step inside your system, teleport between services, and ask Tessa what's wrong.
 

--- a/docs/Resources/Terms-and-Concepts/IAPM/index.md
+++ b/docs/Resources/Terms-and-Concepts/IAPM/index.md
@@ -23,6 +23,17 @@ graph LR
     C --> E[Web Interface]
 ```
 
+## Service Types on the Service Map
+
+IAPM automatically discovers and displays two types of services:
+
+| Type | Definition | Billable | How Detected |
+|------|-----------|----------|--------------|
+| **Instrumented Service** | An application instance emitting telemetry via OpenTelemetry SDK | Yes (1 node) | `service.name` in OTel Resource |
+| **Inferred Service** | An entity referenced by span attributes with no direct telemetry | No | `db.system`, `server.address`, `peer.service` in span attributes |
+
+Both appear on the Service Map. When an inferred service becomes instrumented (you add OpenTelemetry to it), IAPM automatically upgrades it in place, preserving its connections and history.
+
 ## Key Characteristics
 
 | Feature | Description |


### PR DESCRIPTION
IAPM terms page gets a new "Service Types on the Service Map" section defining instrumented services (billable, OTel SDK) vs inferred services (non-billable, detected from span attributes). APM terms page clarifies per-node pricing = per instrumented service.