### PR TITLE
Update installers to DC.latest filename, add 1.12.1 and 1.14.0 releas…

### DIFF
--- a/docs/IAPM/3D/Guides/Installation/Windows/index.md
+++ b/docs/IAPM/3D/Guides/Installation/Windows/index.md
@@ -11,16 +11,16 @@ Free to install. A subscription is required to use IAPM. Learn more about [Steam
 
 ## Offline Installer (MSI)
 
-[Latest Release Build :material-download:](https://ifapm.blob.core.windows.net/release/rtm/msi/ImmersiveAPM.latest.msi){ .md-button .md-button--primary }
-[Latest Beta Build :material-download:](https://ifapm.blob.core.windows.net/release/beta/msi/ImmersiveAPM.latest.msi){ .md-button }
-[Latest Alpha Build :material-download:](https://ifapm.blob.core.windows.net/release/alpha/msi/ImmersiveAPM.latest.msi){ .md-button }
+[Latest Release Build :material-download:](https://ifapm.blob.core.windows.net/release/rtm/msi/DC.latest.msi){ .md-button .md-button--primary }
+[Latest Beta Build :material-download:](https://ifapm.blob.core.windows.net/release/beta/msi/DC.latest.msi){ .md-button }
+[Latest Alpha Build :material-download:](https://ifapm.blob.core.windows.net/release/alpha/msi/DC.latest.msi){ .md-button }
 
 1. Click on the button above to download the installer for IAPM for Windows from the cloud. The file size is around `1.5GB`
     ![Download](img/1.download.png)
 
 1. Run the installer
 
-    Navigate to your Downloads folder, click on the installer called `ImmersiveAPM.latest.msi` and run it.
+    Navigate to your Downloads folder, click on the installer called `DC.latest.msi` and run it.
 
     ![Download](img/2.open.png)
 

--- a/docs/IAPM/3D/Guides/Installation/macOS/index.md
+++ b/docs/IAPM/3D/Guides/Installation/macOS/index.md
@@ -13,17 +13,17 @@ Learn more about [Steam](https://store.steampowered.com/about/){ target="_blank"
 ## Offline Installer (DMG)
 
 <!--
-[Latest Release Build :material-download:](https://ifapm.blob.core.windows.net/release/rtm/dmg/ImmersiveAPM.latest.dmg){ .md-button .md-button--primary }
-[Latest Beta Build :material-download:](https://ifapm.blob.core.windows.net/release/beta/dmg/ImmersiveAPM.latest.dmg){ .md-button }
+[Latest Release Build :material-download:](https://ifapm.blob.core.windows.net/release/rtm/dmg/DC.latest.dmg){ .md-button .md-button--primary }
+[Latest Beta Build :material-download:](https://ifapm.blob.core.windows.net/release/beta/dmg/DC.latest.dmg){ .md-button }
 -->
-[Latest Alpha Build :material-download:](https://ifapm.blob.core.windows.net/release/alpha/dmg/ImmersiveAPM.latest.dmg){ .md-button }
+[Latest Alpha Build :material-download:](https://ifapm.blob.core.windows.net/release/alpha/dmg/DC.latest.dmg){ .md-button }
 
 1. Click on the button above to download the installer for IAPM for macOS from the cloud. The file size is around `1.5GB`
 
-1. Open the Disk Image file (DMG) and drag to your `Applications`.
+1. Open the Disk Image file (DMG) and drag `DC.app` to your `Applications` folder.
 
-1. Open `Terminal` and execute the following command to remove `Immersive APM` from quarantine.
+1. Open `Terminal` and execute the following command to remove `DC` from quarantine.
 
 ```bash
-xattr -d com.apple.quarantine /Applications/Immersive\ APM.app
+xattr -d com.apple.quarantine /Applications/DC.app
 ```

--- a/docs/IAPM/3D/release-notes.md
+++ b/docs/IAPM/3D/release-notes.md
@@ -2,6 +2,57 @@
 
 ## Version History
 
+### 1.14.0 <small>April 20, 2026</small> { id="1.14.0" }
+
+**Introduction:**
+
+This release delivers a big jump in in-world information density. Services and dependencies now carry their own content screens with error tables, log tables, and cost summaries, and you can tap any table row to teleport directly to the matching facility. A new force-directed service graph replaces the previous physics layout with smoother, more stable placement. Tessa picks up a new visual companion, Boop, for contextual guidance.
+
+**New Features:**
+
+- **Per-Facility Content Screens**: Services, dependencies, and the root hub each have their own error table, log table, and cost summary screens, pulled live from the telemetry stream.
+- **Row-Tap Teleport**: Tap any row in a service, dependency, error, or log table to teleport directly to the corresponding facility.
+- **GenAI Cost Visibility**: Dedicated cost summary screens on the root hub, service facilities, and the Diagnostics Room show GenAI spend and token usage at a glance.
+
+**Improvements:**
+
+- **New Service Graph Engine**: The service graph uses a new force-directed layout for smoother transitions, stable node placement, and reliable prevention of ghost nodes.
+- **Auto-Flatten Graph**: The graph flattens to 2D when you are in the hub and unfolds to 3D when you approach a facility.
+- **Portal Hub Return**: Facility portals now reliably return you to the central hub, with correct orientation and landing position.
+- **Loading Screen Timing**: The loading screen now waits for all environment scenes to finish loading before handing off to the world.
+- **Paused World**: Pausing the world now freezes the service graph, photons, and physics so you can inspect the scene without motion.
+- **Tooltip and Label Polish**: F6 copy hints standardized across tooltips, proximity labels refined, and dependency type now displays database and messaging system details.
+- **Installer Packaging**: New Windows Installer (MSI) with dialog and banner graphics, and a new macOS disk image (DMG) distribution flow.
+
+**Bug Fixes:**
+
+- Fixed completed spans being mistakenly classified as lost with inflated durations.
+- Fixed ghost nodes appearing in the service graph during high churn.
+- Fixed avatar falling through the ground after portal teleport.
+- Fixed portal ring orientation so portals face the hub center correctly.
+- Fixed graph layout instability with improved bounding box handling and cooling behavior.
+- Fixed Diagnostics Room width computation after scene hierarchy changes.
+- Fixed numerous trace table and tooltip rendering issues.
+
+**Known Issues:**
+
+- macOS support is experimental and may lack full feature parity with Windows builds.
+
+### 1.12.1 <small>April 5, 2026</small> { id="1.12.1" }
+
+**Introduction:**
+
+This patch refines service context awareness so Tessa can ground her answers in the specific service you are looking at.
+
+**Improvements:**
+
+- Service facilities now carry richer platform context (runtime, operating system, service version) that Tessa can consult when answering questions.
+- Refined service context providers for more accurate location and topic awareness.
+
+**Bug Fixes:**
+
+- Fixed an error when the grid selection modal loads before authentication completes.
+
 ### 1.12.0 <small>April 3, 2026</small> { id="1.12.0" }
 
 **Introduction:**

--- a/docs/IAPM/3D/steam/1.12.1.md
+++ b/docs/IAPM/3D/steam/1.12.1.md
@@ -1,0 +1,10 @@
+# IAPM 1.12.1
+
+This patch refines service context awareness so Tessa can ground her answers in the specific service you are looking at.
+
+## What's New
+- Service facilities now carry richer platform context (runtime, operating system, service version) that Tessa can consult when answering questions.
+- Refined service context providers for more accurate location and topic awareness.
+
+## Fixes
+- Fixed an error when the grid selection modal loads before authentication completes.

--- a/docs/IAPM/3D/steam/1.14.0.md
+++ b/docs/IAPM/3D/steam/1.14.0.md
@@ -1,0 +1,22 @@
+# IAPM 1.14.0
+
+A big jump in in-world information density. Services and dependencies now carry their own content screens with error tables, log tables, and cost summaries, and you can tap any table row to teleport directly to the matching facility. A new force-directed service graph replaces the previous physics layout for smoother, more stable placement, and Tessa picks up a new visual companion named Boop for contextual guidance.
+
+## What's New
+- Boop Companion: a new visual companion in the world with a radial menu for quick actions and expressive animations for Tessa's responses.
+- Per-facility content screens: services, dependencies, and the root hub each have their own error tables, log tables, and cost summary screens, pulled live from the telemetry stream.
+- Row-tap teleport: tap any row in a service, dependency, error, or log table to teleport directly to the corresponding facility.
+- GenAI cost visibility: dedicated cost summary screens show GenAI spend and token usage at a glance.
+- New service graph engine with force-directed layout for smoother transitions and stable node placement.
+- Auto-flatten graph that switches to 2D in the hub and unfolds to 3D when you approach a facility.
+- Pausing the world now freezes the service graph, photons, and physics so you can inspect the scene without motion.
+- Refreshed Windows installer and new macOS disk image distribution flow.
+
+## Fixes
+- Fixed completed spans being mistakenly classified as lost with inflated durations.
+- Fixed ghost nodes appearing in the service graph during high churn.
+- Fixed avatar falling through the ground after portal teleport.
+- Fixed portal ring orientation so portals face the hub center correctly.
+- Fixed graph layout instability with improved bounding box handling and cooling behavior.
+- Fixed Diagnostics Room width computation after scene hierarchy changes.
+- Fixed numerous trace table and tooltip rendering issues.

--- a/docs/IAPM/Studio/release-notes.md
+++ b/docs/IAPM/Studio/release-notes.md
@@ -5,6 +5,42 @@
 
 ## Version History
 
+### 0.8.0 <small>April 16, 2026</small> { id="0.8.0" }
+
+**Introduction:**
+
+This release makes Studio genuinely multi-workspace: every chat tab now binds to its own workspace, so you can work on several projects side by side without cross-talk. A redesigned tool card surface shows Tessa's actions with side-by-side diffs, chat sessions survive restarts, and Studio is now available for both Windows and macOS.
+
+**New Features:**
+
+- **Per-Tab Workspace Binding**: Each chat tab can target a different workspace, with a workspace picker available from the new-tab button and a current-workspace indicator in the status bar.
+- **Tool Card UI**: Tessa's tool actions render as expandable cards with side-by-side before/after diffs so you can see exactly what she changed.
+- **Session Restore**: Your open tabs and chat history are restored automatically when you reopen Studio.
+- **macOS Distribution**: Studio now ships a macOS disk image alongside the Windows installer.
+
+**Improvements:**
+
+- Rebranded app shell to DC Studio with a matching Windows installer experience.
+- Background authentication token refresh so long sessions no longer hit expired-token errors.
+- Installer pipeline overhauled for both Windows (MSI) and macOS (DMG) distribution, with cleaner upgrades and a new blob-published download flow.
+- Version is now shown on the login screen for easier support and troubleshooting.
+
+**Bug Fixes:**
+
+- Fixed startup crash related to embedded browser initialization and user data folder location.
+- Fixed race condition where switching workspaces could spawn a ghost tab.
+- Fixed workspace switching losing chat state mid-conversation.
+
+### 0.7.1 <small>April 5, 2026</small> { id="0.7.1" }
+
+**Introduction:**
+
+This patch cleans up Tessa's output rendering for more consistent formatting in chat responses.
+
+**Bug Fixes:**
+
+- Fixed assorted output formatting glitches in Tessa's responses.
+
 ### 0.7.0 <small>April 3, 2026</small> { id="0.7.0" }
 
 **Introduction:**

--- a/docs/IAPM/Web/release-notes.md
+++ b/docs/IAPM/Web/release-notes.md
@@ -2,6 +2,18 @@
 
 ## Version History
 
+### 3.132.0 <small>April 5, 2026</small> { id="3.132.0" }
+
+**Introduction:**
+
+This patch keeps Tessa's memory intact across multi-step tool conversations, so follow-up questions no longer lose the context of earlier actions.
+
+**Bug Fixes:**
+
+- Fixed Tessa losing file and tool context between conversation turns when using server-side tools. Follow-up questions about previously inspected data now work correctly.
+
+---
+
 ### 3.131.0 <small>April 2, 2026</small> { id="3.131.0" }
 
 **Introduction:**

--- a/docs/Resources/whats-new.md
+++ b/docs/Resources/whats-new.md
@@ -6,6 +6,20 @@ Recent updates and features across IAPM. For complete version history, see the r
 
 ## Latest Highlights
 
+### In-World Content Screens & Per-Tab Workspaces (3D v1.14, Studio v0.8)
+
+Big density jump in the 3D world with per-facility content screens, and Studio makes every chat tab its own workspace.
+
+| Feature | Description |
+|---------|-------------|
+| **Per-Facility Content Screens** | Services and dependencies carry their own error, log, and cost summary screens in the 3D world |
+| **Row-Tap Teleport** | Tap any row in a table to teleport directly to the matching facility |
+| **New Service Graph Engine** | Force-directed layout with smoother transitions and stable node placement |
+| **Per-Tab Workspaces** | Each Studio chat tab binds to its own workspace, so multiple projects run side by side |
+| **Tool Card UI** | Studio renders Tessa's actions as cards with side-by-side before/after diffs |
+| **Session Restore** | Studio reopens your tabs and chat history automatically |
+| **macOS Studio** | Studio now ships a macOS disk image alongside the Windows installer |
+
 ### Skills System & Multimodal Vision (3D v1.12, Studio v0.7)
 
 Tessa gains extensible capabilities and the ability to analyze images.
@@ -43,6 +57,11 @@ Full adoption of the OpenTelemetry-native data model across all trace and log vi
 
 ### April 2026
 
+- **3D v1.14**: Per-facility content screens, row-tap teleport, new force-directed service graph, Boop companion, macOS disk image
+- **3D v1.12.1**: Richer service platform context for Tessa
+- **Studio v0.8**: Per-tab workspace binding, tool card UI with diffs, session restore, macOS distribution
+- **Studio v0.7.1**: Output formatting fixes
+- **Web 3.132**: Fixed Tessa losing context between multi-step tool turns
 - **3D v1.12**: Skills system, multimodal vision, diagnostics tools, Studio feature parity
 - **Web 3.131**: Smarter diagnostics, energy dashboard redesign, vision support
 - **Studio v0.7**: Multimodal vision, Skills, memory and context


### PR DESCRIPTION
…e notes

- Windows installer: ImmersiveAPM.latest.msi -> DC.latest.msi
- macOS installer: ImmersiveAPM.latest.dmg -> DC.latest.dmg
- macOS app path: /Applications/Immersive APM.app -> /Applications/DC.app
- Add 3D v1.14.0 and v1.12.1 release notes
- Update Studio and Web release notes
- Refresh What's New with v1.14 highlights (per-facility content screens, row-tap teleport, Boop companion, per-tab workspaces, tool card UI)