### PR TITLE
docs(tessa): scrub "unlimited" AI claims, update Tessa Personal tiers

### DIFF
--- a/docs/DC/3D/Reference/assistant-commands.md
+++ b/docs/DC/3D/Reference/assistant-commands.md
@@ -91,12 +91,14 @@ The remaining energy is visible in the **Energy Bar** in the chat panel. Energy 
 |------|------------------------------|-----------------------------|
 | **Start** | ~1 query | 7 |
 | **Visualize** | ~8 queries | 35 |
-| **Analyze** | Unlimited | Unlimited |
-| **Fuse** | Unlimited | Unlimited |
+| **Analyze** | Large, scales per node | Large, scales per node |
+| **Fuse** | Large, scales per node | Large, scales per node |
 
 Limits are enforced in 6-hour rolling windows, not as a single daily pool: the daily total is divided across four windows. When a window's budget is spent, energy refills as the next window opens. The window budget is measured in tokens, so the query counts above are approximate: a few large requests consume a window faster than several small ones. Your account energy panel shows the exact remaining budget.
 
-These figures apply to Grid subscriptions (Start, Visualize, Analyze, Fuse). Personal subscriptions are a separate axis: they carry energy levels (E1, E5, E15) measured in monthly token allotments rather than per-window query caps. Your account energy panel shows the active limit for either.
+No tier is unlimited. Analyze and Fuse carry large budgets that scale with your monitored node count, not infinite ones. When a window's budget is spent, the assistant drops to lighter responses (the Conserving state) and is never blocked, exactly as every paid tier does.
+
+These figures apply to Grid subscriptions (Start, Visualize, Analyze, Fuse). Personal subscriptions are a separate axis: they carry energy levels (E5, E25, E50, E150) measured in monthly token allotments rather than per-window query caps. Your account energy panel shows the active limit for either.
 
 ## Related
 

--- a/docs/Setup/Plans/index.md
+++ b/docs/Setup/Plans/index.md
@@ -18,7 +18,7 @@ IAPM uses **per-node pricing**. A node is any monitored application instance sen
 | IAPM (3D & VR) | :material-check: | :material-check: | :material-check: | :material-check: |
 | **Throughput** | 50/sec | 200/sec | 1,000/sec | 2,000/sec |
 | **Data Retention** | 7 days | 30 days | 90 days | 365 days |
-| **AI (Tessa)** | 7 queries/day | 35 queries/day | Unlimited + Code Fix | Unlimited + Code Fix + Infra |
+| **AI (Tessa)** | 7 queries/day | 35 queries/day | Large daily budget + Code Fix | Large daily budget + Code Fix + Infra |
 | **Support** | Discord | Chat/Email | Chat/Email/Phone | Chat/Email/Phone |
 | **Uptime SLA** | - | 99% | 99.9% | 99.99% |
 | **Dedicated Success Rep** | :material-close: | :material-close: | :material-check: | :material-check: |
@@ -26,6 +26,8 @@ IAPM uses **per-node pricing**. A node is any monitored application instance sen
 | **Early Access Features** | :material-close: | :material-close: | :material-close: | :material-check: |
 
 *Throughput = traces + logs per second*
+
+*AI (Tessa) usage is a daily budget that scales with your monitored nodes, not an unlimited allowance. No plan is ever blocked: when a budget is spent, Tessa keeps working with lighter, faster responses until it refills.*
 
 ## Plan Details
 
@@ -61,7 +63,7 @@ Improve your application visualization capabilities by incorporating historical 
 - 99.9% uptime SLA
 - 1,000 traces + logs per second
 - 90 days data retention
-- Unlimited AI Assistant + Code Fix
+- Large daily AI Assistant budget + Code Fix
 - Phone support
 - Dedicated success representative
 - Professional consulting services
@@ -75,7 +77,7 @@ Elevate your application monitoring and management with the stability, scalabili
 - 99.99% uptime SLA
 - 2,000 traces + logs per second
 - 365 days data retention
-- Unlimited AI Assistant + Code Fix + Infra
+- Large daily AI Assistant budget + Code Fix + Infra
 - Phone support
 - Dedicated success representative
 - Professional consulting services


### PR DESCRIPTION
Render the No-Unlimited ruling (energy-model.md) and the SP-077 Tessa Personal tiers (pricing.md) onto the docs surface, per Friday regeneration trigger (bus #712, refs PR #2886).

- Plans: AI (Tessa) Analyze/Fuse "Unlimited" -> "Large daily budget"; added a finite-budget note (scales per node, never blocked, Conserving floor).
- assistant-commands: Analyze/Fuse query table "Unlimited" -> "Large, scales per node"; added a no-unlimited / never-blocked clause; updated Tessa Personal energy levels E1/E5/E15 -> E5/E25/E50/E150 (E1 and E15 retired).

Grid tier prices unchanged. Agentic Mode E5+ unchanged (E5 is the entry tier). Authorities: pricing.md (price), energy-model.md (budget). Build clean.