### PR TITLE
docs(install): point download buttons at branded Front Door host, off…

### DIFF
--- a/docs/DC/3D/Guides/Installation/Windows/index.md
+++ b/docs/DC/3D/Guides/Installation/Windows/index.md
@@ -11,9 +11,9 @@ Free to install. A subscription is required to use IAPM. Learn more about [Steam
 
 ## Offline Installer (MSI)
 
-[Latest Stable Build :material-download:](https://ifdl.blob.core.windows.net/release/stable/DC.latest.msi){ .md-button .md-button--primary }
-[Latest Beta Build :material-download:](https://ifdl.blob.core.windows.net/release/beta/DC.latest.msi){ .md-button }
-[Latest Alpha Build :material-download:](https://ifdl.blob.core.windows.net/release/alpha/DC.latest.msi){ .md-button }
+[Latest Stable Build :material-download:](https://downloads.immersivefusion.com/release/stable/DC.latest.msi){ .md-button .md-button--primary }
+[Latest Beta Build :material-download:](https://downloads.immersivefusion.com/release/beta/DC.latest.msi){ .md-button }
+[Latest Alpha Build :material-download:](https://downloads.immersivefusion.com/release/alpha/DC.latest.msi){ .md-button }
 
 1. Click on the button above to download the installer for IAPM for Windows from the cloud. The file size is around `1.5GB`
     ![Download](img/1.download.png)

--- a/docs/DC/3D/Guides/Installation/macOS/index.md
+++ b/docs/DC/3D/Guides/Installation/macOS/index.md
@@ -15,7 +15,7 @@ Learn more about [Steam](https://store.steampowered.com/about/){ target="_blank"
 !!! info "Alpha channel only on macOS"
     The macOS build of IAPM is currently published to the **alpha** channel only. Stable and beta DMGs are not yet available. Windows builds on all three channels remain available from the [Windows installation page](../Windows/index.md).
 
-[Latest Alpha Build :material-download:](https://ifdl.blob.core.windows.net/release/alpha/DC.latest.dmg){ .md-button }
+[Latest Alpha Build :material-download:](https://downloads.immersivefusion.com/release/alpha/DC.latest.dmg){ .md-button }
 
 1. Click on the button above to download the installer for IAPM for macOS from the cloud. The file size is around `1.5GB`
 

--- a/docs/DC/Studio/Guides/Installation/index.md
+++ b/docs/DC/Studio/Guides/Installation/index.md
@@ -9,7 +9,7 @@ IAPM Studio is a native desktop application distributed as a standalone installe
 
 ## Download
 
-[Latest Alpha Build :material-microsoft-windows:](https://ifdl.blob.core.windows.net/release/alpha/DCS.latest.msi){ .md-button .md-button--primary }
+[Latest Alpha Build :material-microsoft-windows:](https://downloads.immersivefusion.com/release/alpha/DCS.latest.msi){ .md-button .md-button--primary }
 
 A subscription is required to use IAPM Studio.
 


### PR DESCRIPTION
… raw blob

Install pages linked straight to ifdl.blob.core.windows.net (raw blob: ugly, SmartScreen warnings, leaks the storage account). Repointed to the branded Front Door host downloads.immersivefusion.com (same flat /release/{ring}/ path, DC.latest.* / DCS.latest.*). All five verified 200 over HTTPS via Front Door.

- DC/3D Windows: stable + beta + alpha .msi
- DC/3D macOS: alpha .dmg
- DC Studio: alpha DCS .msi

Each surface references the canonical download host directly (docs does NOT bounce through the storefront). Host survives the DeepCube rename via a profile-level swap. Founder-authorized cross-lane edit (normally Lovelace).